### PR TITLE
feat(terraform): implement VPC module with 3 AZs and EKS subnet autodiscovery tagging

### DIFF
--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,15 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  cidr_block           = "10.0.0.0/16"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24"]
+  azs                  = ["ap-south-1a", "ap-south-1b"]
+
+  enable_nat_gateway = true
+
+  tags = {
+    Environment = "dev"
+    Project     = "eks-project"
+  }
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -2,11 +2,13 @@ module "vpc" {
   source = "../../modules/vpc"
 
   cidr_block           = "10.0.0.0/16"
-  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
-  private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24"]
-  azs                  = ["ap-south-1a", "ap-south-1b"]
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  azs                  = ["ap-south-1a", "ap-south-1b", "ap-south-1c"]
 
   enable_nat_gateway = true
+
+  cluster_name = "dev-eks"
 
   tags = {
     Environment = "dev"

--- a/terraform/environments/dev/provider.tf
+++ b/terraform/environments/dev/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-south-1"
+}

--- a/terraform/environments/dev/terraform.tf
+++ b/terraform/environments/dev/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -13,8 +13,16 @@ resource "aws_subnet" "Public" {
   availability_zone       = each.value
   map_public_ip_on_launch = true
 
-  tags = merge(var.tags, { Name = "public-subnet-${each.value}" })
+  tags = merge(
+    var.tags,
+    {
+      Name                                        = "public-subnet-${each.value}"
+      "kubernetes.io/role/elb"                    = "1"
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    }
+  )
 }
+
 
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.main.id
@@ -46,7 +54,14 @@ resource "aws_subnet" "Private" {
   cidr_block        = each.key
   availability_zone = each.value
 
-  tags = merge(var.tags, { Name = "private-subnet-${each.value}" })
+  tags = merge(
+    var.tags,
+    {
+      Name                                        = "private-subnet-${each.value}"
+      "kubernetes.io/role/internal-elb"           = "1"
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    }
+  )
 }
 
 resource "aws_route_table" "private_rt" {

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,81 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = var.tags
+}
+
+resource "aws_subnet" "Public" {
+  vpc_id                  = aws_vpc.main.id
+  for_each                = zipmap(var.public_subnet_cidrs, var.azs)
+  cidr_block              = each.key
+  availability_zone       = each.value
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, { Name = "public-subnet-${each.value}" })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, { Name = "main-igw" })
+}
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, { Name = "public-rt" })
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public_rt_assoc" {
+  for_each       = aws_subnet.Public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_subnet" "Private" {
+  vpc_id            = aws_vpc.main.id
+  for_each          = zipmap(var.private_subnet_cidrs, var.azs)
+  cidr_block        = each.key
+  availability_zone = each.value
+
+  tags = merge(var.tags, { Name = "private-subnet-${each.value}" })
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, { Name = "private-rt" })
+}
+
+resource "aws_route_table_association" "private_rt_assoc" {
+  for_each       = aws_subnet.Private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private_rt.id
+}
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "ngw" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = values(aws_subnet.Public)[0].id
+
+}
+
+resource "aws_route" "private_internet_access" {
+  count                  = var.enable_nat_gateway ? 1 : 0
+  nat_gateway_id         = aws_nat_gateway.ngw[0].id
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnets_id" {
+  value = [for subnet in values(aws_subnet.Public) : subnet.id]
+}
+
+output "private_subnets_id" {
+  value = [for subnet in values(aws_subnet.Private) : subnet.id]
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,44 @@
+## CORE VARIABLES
+variable "cidr_block" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+## SUBNET VARIABLE
+
+variable "public_subnet_cidrs" {
+  type = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == length(var.azs) && length(var.public_subnet_cidrs) > 0
+    error_message = "Public subnet count must match AZ count."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  type = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) == length(var.azs) && length(var.private_subnet_cidrs) > 0
+    error_message = "Private subnet count must match AZ count."
+  }
+}
+
+variable "azs" {
+  type = list(string)
+}
+
+## NAT CONFIGURATION VARIABLE
+
+variable "enable_nat_gateway" {
+  type    = bool
+  default = false
+}
+
+variable "single_nat_gateway" {
+  type    = bool
+  default = true
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -42,3 +42,7 @@ variable "single_nat_gateway" {
   type    = bool
   default = true
 }
+
+variable "cluster_name" {
+  type = string
+}


### PR DESCRIPTION
This PR updates the VPC module to fully satisfy the Definition of Done:

- 3 public subnets across AZs
- 3 private subnets across AZs
- NAT Gateway in public subnet
- Proper EKS subnet tagging (role + cluster autodiscovery)

close #3 